### PR TITLE
Filter latent variables from online-EM evidence during BN merge

### DIFF
--- a/episodic.lisp
+++ b/episodic.lisp
@@ -263,8 +263,14 @@
     (setq new-nodes (make-array (length new-nodes) :initial-contents new-nodes :fill-pointer t))
     (setq new-nodes (cons new-nodes (make-graph-edges new-nodes)))
     (if latent-vars
-	(online-em new-nodes latent-vars (cons p (make-array 0)))
-	new-nodes)))
+        (let ((evidence-factors
+                (make-array 0 :fill-pointer t :adjustable t)))
+          (loop
+            for factor being the elements of p
+            when (not (rule-based-cpd-latent-p factor)) do
+              (vector-push-extend factor evidence-factors))
+          (online-em new-nodes latent-vars (cons evidence-factors (make-array 0))))
+        new-nodes)))
 
 #| Update distribution over states |#
 


### PR DESCRIPTION
### Motivation
- `online-em` was being called with all factors from the new BN (including CPDs marked `:latent-p`), and `make-observations` converts factor rules into evidence so latent nodes were effectively treated as soft observations which pins their posteriors (e.g., to `0.25`) and distorts updates for observed nodes.

### Description
- Changed `new-combine-bns` in `episodic.lisp` to construct an `evidence-factors` vector containing only non-latent CPDs and pass `(cons evidence-factors (make-array 0))` to `online-em` instead of passing the full `p` vector, thereby excluding latent-marked factors from the evidence used by EM.

### Testing
- Ran `git commit` for the change which succeeded. 
- Attempted to run an SBCL-based reproduction (`sbcl --non-interactive ...`) to validate runtime behavior, but the run failed because `sbcl` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d4fe326c8322aa7134af644f8566)