### PR TITLE
Update EM to replace posteriors for latent variables and their descendants

### DIFF
--- a/online-em.lisp
+++ b/online-em.lisp
@@ -132,15 +132,39 @@ Groups rules by parent-context and normalizes counts within each group."
       (compile-bn-priors bn)
     (loopy-belief-propagation bn-with-priors evidence priors '+ lr :singleton-only nil)))
 
+(defun online-em-affected-vars (bn latent-vars)
+  "Return LATENT-VARS and every descendant variable reachable via child links."
+  (loop
+    with queue = (copy-list latent-vars)
+    with affected = (make-hash-table :test #'equal)
+    with factors = (car bn)
+    while queue
+    for current = (pop queue)
+    for current-cpd = (find current factors :key #'rule-based-cpd-dependent-id :test #'equal)
+    do
+       (unless (gethash current affected)
+         (setf (gethash current affected) t)
+         (when current-cpd
+           (loop
+             for child-cpd being the elements of factors
+             for child-id = (rule-based-cpd-dependent-id child-cpd)
+             when (and (not (gethash child-id affected))
+                       (cpd-child-p child-cpd current-cpd))
+               do
+                  (push child-id queue))))
+    finally
+       (return affected)))
+
 (defun online-em-replace-latents-with-posteriors (bn posterior-bn latent-vars)
   (loop
     with dim = (array-dimension (car bn) 0)
+    with affected-vars = (online-em-affected-vars bn latent-vars)
     with new-bn-arr = (make-array dim)
     for i from 0 below dim 
     for cpd = (aref (car bn) i)
     for dep-id = (rule-based-cpd-dependent-id cpd)
     for posterior-cpd = (aref (car posterior-bn) i)
-    when (member dep-id latent-vars :test #'equal)
+    when (gethash dep-id affected-vars)
       do
 	 (setf (rule-based-cpd-count posterior-cpd)
 	       (rule-based-cpd-count cpd))


### PR DESCRIPTION
### Motivation
- EM replacement previously targeted only declared latent variables, which prevented inferred beliefs from propagating to their child variables and broke intended posterior propagation.
- The change ensures that EM updates affect the full downstream closure of latent variables so children receive updated CPDs after inference.

### Description
- Added `online-em-affected-vars` which computes the closure of `latent-vars` plus all descendant variables reachable via child links using `cpd-child-p` and `rule-based-cpd-dependent-id`.
- Updated `online-em-replace-latents-with-posteriors` to compute `affected-vars` via `online-em-affected-vars` and replace CPDs when `dep-id` is in `affected-vars` instead of only when it is a direct member of `latent-vars`.
- Preserved existing count handling (`rule-based-cpd-count`) and the `get-local-coverings` / `update-cpd-rules` flow used when installing posterior CPDs.

### Testing
- Attempted to run an automated load test by invoking SBCL to load `package.lisp`, `graph-representation.lisp`, and `online-em.lisp`, but the command failed because `sbcl` is not installed in the environment (automated test failed).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ea6dc2c08322b331d142a8ccae38)