### PR TITLE
Fix online EM M-step parent-context normalization

### DIFF
--- a/online-em.lisp
+++ b/online-em.lisp
@@ -98,28 +98,34 @@ If a rule already has a count, preserve it; otherwise initialize from alpha*P(ru
 (defun online-em-m-step-cpd (cpd posterior-cpd &key (min-prob 1.0d-12))
   "Closed-form local M-step for a rule-based CPD.
 Groups rules by parent-context and normalizes counts within each group."
-  (let ((totals (make-hash-table :test #'equal))
-        (posterior-map (online-em-rule-map posterior-cpd)))
-    ;; I think this totals computation is incorrect. Rules that belong to the same row/parent context can have different rule conditions. For example, the parent context X=1 is compatible with this other context X=1, A=2. But it appears that this version only updates the totals for exact matches to the rule parent context. (normalize-cpd-rules) handles this, but I'm unsure of how much I need to cut/copy/abstract out into a function to reuse that code here.
-    (loop
-	  for rule being the elements of (rule-based-cpd-rules posterior-cpd)
-          for parent-key = (online-em-parent-key posterior-cpd rule)
-	  do
-          (incf (gethash parent-key totals 0.0d0)
-                (float (rule-count rule) 1.0d0)))
-    (loop
-	  for rule being the elements of (rule-based-cpd-rules cpd)
-          for key = (online-em-rule-key rule)
-          for posterior-rule = (gethash key stats-map)
-          for parent-key = (online-em-parent-key cpd rule)
-          for denom = (gethash parent-key totals 0.0d0)
-	  do
-            (setf (rule-probability rule)
-                  (cond ((and posterior-rule (> denom 0.0d0))
-                         (max min-prob (/ (float (rule-count posterior-rule) 1.0d0) denom)))
-                        (t min-prob)))
-	  (setf (rule-count rule) denom))
-    (normalize-rule-probabilities cpd (rule-based-cpd-dependent-id cpd))))
+  (if (null posterior-cpd)
+      cpd
+      (labels ((parent-setting-rule (rule phi)
+                 (let ((parent-setting (copy-cpd-rule rule)))
+                   (remhash (rule-based-cpd-dependent-id phi)
+                            (rule-conditions parent-setting))
+                   parent-setting))
+               (normalization-total (rule)
+                 (let ((parent-setting (parent-setting-rule rule cpd)))
+                   (loop for posterior-rule being the elements of (rule-based-cpd-rules posterior-cpd)
+                         when (compatible-rule-p posterior-rule parent-setting
+                                                 posterior-cpd posterior-cpd)
+                         sum (float (or (rule-count posterior-rule) 0.0d0) 1.0d0)))))
+        (let ((posterior-map (online-em-rule-map posterior-cpd)))
+          (loop
+            for rule being the elements of (rule-based-cpd-rules cpd)
+            for key = (online-em-rule-key rule)
+            for posterior-rule = (gethash key posterior-map)
+            for denom = (normalization-total rule)
+            do
+               (setf (rule-probability rule)
+                     (cond ((and posterior-rule (> denom 0.0d0))
+                            (max min-prob
+                                 (/ (float (or (rule-count posterior-rule) 0.0d0) 1.0d0)
+                                    denom)))
+                           (t min-prob)))
+               (setf (rule-count rule) denom)))
+        (normalize-rule-probabilities cpd (rule-based-cpd-dependent-id cpd)))))
 
 (defun online-em-coerce-evidence (datum)
   "Convert DATUM into evidence expected by LOOPY-BELIEF-PROPAGATION."


### PR DESCRIPTION
### Motivation
- The M-step normalization previously grouped posterior counts by exact parent-key matches, which missed compatible parent contexts (e.g., `X=1` vs `X=1,A=2`) and produced incorrect denominators when normalizing rule probabilities.
- The codebase already encodes sufficient statistics in the posterior factors after inference, so the M-step should consume those posterior factors rather than relying on a separate stats BN or an incorrect `stats-map` lookup.

### Description
- Rewrote `online-em-m-step-cpd` to compute normalization denominators by aggregating over posterior rules that are `compatible-rule-p` with a rule's parent-setting, using a new `parent-setting-rule` helper and a `normalization-total` label.
- Switched the M-step numerator lookup to use the `posterior-map` (from `online-em-rule-map`) and removed the stale `stats-map` reference.
- Added a guard so that if `posterior-cpd` is `nil` the input `cpd` is returned unchanged, avoiding spurious updates in edge cases.
- Kept the final call to `normalize-rule-probabilities` to ensure CPD rows are normalized after updating `rule-probability` and `rule-count`.

### Testing
- Verified the patch was applied to `online-em.lisp` and that `online-em-m-step-cpd` source now implements compatibility-based denominator computation and uses `posterior-map` for numerators.
- Applied the patch successfully with the project patch tool (`apply_patch` returned success). 
- Attempted to load the project with `sbcl` using `sbcl --non-interactive --eval '(load "hems.asd")' --quit`, but the runtime check could not be executed because `sbcl` is not installed in this environment. 
- No automated unit tests were executed in this environment due to the missing Lisp runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d9e45a0c832280e004c5b49ef6e2)